### PR TITLE
Update to new PHPScraper namespace

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -22,7 +22,7 @@ function og_scraper( $args ) {
 
         
             
-        $web = new \spekulatius\phpscraper();
+        $web = new \Spekulatius\PHPScraper\PHPScraper;
 
         $web->go($url);
 


### PR DESCRIPTION
spekulatius/PHPScraper#150 changed the namespace almost 2 years ago. Prior to this change, activating the OG-Scraper plugin will raise HTTP 500. After updating the namespace, I was able to successfully test with the plugin enabled and verify it is presenting OG metadata using opengraph.dev.

I haven't attempted to modify the process of specifying where the `autoload.php` file comes from; users will still have to do that manually after installing the dependencies in the location of their choosing using `composer`.